### PR TITLE
xtheadfmv,xtheadint: Add small corrections

### DIFF
--- a/docinfo.adoc
+++ b/docinfo.adoc
@@ -22,6 +22,7 @@ The list below includes all contributors to this document in alphabetical order:
 * Zhiwei Liu <zhiwei_liu@linux.alibaba.com>
 
 === Changelog
+* 2022-11-04: Fixes for xtheadint, xtheadfmv
 * 2022-09-23: Adding xtheadint extension
 * 2022-09-23: Adding xtheadfmv extension
 * 2022-09-03: xtheadmemidx: Fix load width of lurwu,

--- a/xtheadfmv.adoc
+++ b/xtheadfmv.adoc
@@ -13,8 +13,8 @@ The table below gives an overview of the instructions:
 [cols="^3,^3,12,18",stripes=even,options="header"]
 |===
 | RV32 | RV64 | Mnemonic              | Instruction
-| Y    | N    | th.fmv.x.hw  _rd_, _fs1_ | <<#xtheadfmv-insns-fmv_x_hw>>
 | Y    | N    | th.fmv.hw.x  _rd_, _fs1_ | <<#xtheadfmv-insns-fmv_hw_x>>
+| Y    | N    | th.fmv.x.hw  _rd_, _fs1_ | <<#xtheadfmv-insns-fmv_x_hw>>
 |===
 
 [#xtheadfmv-insns,reftext="Instructions"]

--- a/xtheadfmv/fmv_hw_x.adoc
+++ b/xtheadfmv/fmv_hw_x.adoc
@@ -14,7 +14,7 @@ Encoding::
     { bits:  7, name: 0xb, attr: ['custom-0, 32 bit'] },
     { bits:  5, name: 'rd' },
     { bits:  3, name: 0x1 },
-    { bits:  5, name: 'rs1' },
+    { bits:  5, name: 'fs1' },
     { bits:  5, name: 0x0 },
     { bits:  7, name: 0x60 },
 ]}

--- a/xtheadfmv/fmv_x_hw.adoc
+++ b/xtheadfmv/fmv_x_hw.adoc
@@ -14,7 +14,7 @@ Encoding::
     { bits:  7, name: 0xb, attr: ['custom-0, 32 bit'] },
     { bits:  5, name: 'rd' },
     { bits:  3, name: 0x1 },
-    { bits:  5, name: 'rs1' },
+    { bits:  5, name: 'fs1' },
     { bits:  5, name: 0x0 },
     { bits:  7, name: 0x50 },
 ]}

--- a/xtheadint/ipop.adoc
+++ b/xtheadint/ipop.adoc
@@ -12,11 +12,11 @@ Encoding::
 ....
 {reg:[
     { bits:  7, name: 0xb, attr: ['custom-0, 32 bit'] },
-    { bits:  5, name: 'rd' },
-    { bits:  3, name: 0x1 },
-    { bits:  5, name: 'rs1' },
     { bits:  5, name: 0x0 },
-    { bits:  7, name: 0x60 },
+    { bits:  3, name: 0x0 },
+    { bits:  5, name: 0x0 },
+    { bits:  5, name: 0x5 },
+    { bits:  7, name: 0x0 },
 ]}
 ....
 


### PR DESCRIPTION
I found two issues in the recently added extensions XTheadFmv and XTheadInt.

For XTheadFmv we should use consistent register naming. Let's use `fs1` instead of `rs1` to make it clear which of the operands needs to be a floating-pointer register.

XTheadInt had a missing encoding for ipop.