### PR TITLE
docinfo: Remove manual changelog

### DIFF
--- a/docinfo.adoc
+++ b/docinfo.adoc
@@ -20,20 +20,3 @@ The list below includes all contributors to this document in alphabetical order:
 * Philipp Tomsich <philipp.tomsich@vrull.eu>
 * Yunhai Shang < yunhai@linux.alibaba.com>
 * Zhiwei Liu <zhiwei_liu@linux.alibaba.com>
-
-=== Changelog
-* 2022-11-04: Fixes for xtheadint, xtheadfmv
-* 2022-09-23: Adding xtheadint extension
-* 2022-09-23: Adding xtheadfmv extension
-* 2022-09-03: xtheadmemidx: Fix load width of lurwu,
-              xtheadmac: Fix and simplify extension behaviour
-* 2022-08-25: Adjusting contributors list
-* 2022-08-10: *.adoc: Fix several formatting issues
-* 2022-08-01: Remove XTheadEE and rework availability/permission documentation, adding lifecycle-states,
-              adding doc versioning and changelog
-* 2022-07-29: Adding XTheadEE (mxstatus.theadisaee) and mxstatus.ucme (as part of XTheadCmo)
-* 2022-07-27: Adding XTheadMemPair, XTheadMemIdx, XTheadMac, XThadCondMov, XTheadB[a,b,s]
-* 2022-07-26: Adding XTheadCmo U mode permission, Adding XTHeadSync, XTheadFMemIdx
-* 2022-07-20: Adding XTheadMemPair extension, adding HW requirements for XTheadCmo
-* 2022-07-16: Adding complete XTheadCmo extension
-* 2022-07-12: Initial draft with four CMO instructions


### PR DESCRIPTION
We have an outdated changelog, which might be confusing for users. Let's remove it, which should not be a big issue because we have a git history.