### PR TITLE
Fix description error on `th.ff[01]` on RV32

### DIFF
--- a/xtheadbb/ff0.adoc
+++ b/xtheadbb/ff0.adoc
@@ -24,7 +24,7 @@ Encoding::
 Description::
 Finds the first bit with the value of '0' from the highest bit of _rs1_ and writes the index back into register _rd_.
 If the highest bit of _rs1_ is '0', the result '0' is returned.
-If all the bits in _rs1_ are '1', the result '64' is returned.
+If all the bits in _rs1_ are '1', `XLEN` is returned.
 
 Operation::
 [source,sail]

--- a/xtheadbb/ff1.adoc
+++ b/xtheadbb/ff1.adoc
@@ -24,7 +24,7 @@ Encoding::
 Description::
 Finds the first bit with the value of '1' from the highest bit of _rs1_ and writes the index back into register _rd_.
 If the highest bit of _rs1_ is '1', the result '0' is returned.
-If all the bits in _rs1_ are '0', the result '64' is returned.
+If all the bits in _rs1_ are '0', `XLEN` is returned.
 
 Operation::
 [source,sail]


### PR DESCRIPTION
Operations specify that they return `XLEN` on no-target-bit state (so, it is 32 on RV32, not 64).  Note that they are not RV64-only instructions.

This commit reflects this fact to the description.