### PR TITLE
xtheadmempair: Add some clarifications

### DIFF
--- a/xtheadmempair/ldd.adoc
+++ b/xtheadmempair/ldd.adoc
@@ -27,6 +27,11 @@ from the address _rs1_ + (zero_extend(_imm2_) << 4).
 
 The encoding of this instruction with equal _rd1_, _rd2_ and _rs1_ is reserved.
 
+Note, that there is no atomicity guarantee for this instruction.
+I.e., an implementation can realize this instruction in form of two
+memory transactions and an exception can be handled in-between, in which
+case the whole instruction will be re-executed.
+
 Operation::
 [source,sail]
 --

--- a/xtheadmempair/ldd.adoc
+++ b/xtheadmempair/ldd.adoc
@@ -25,14 +25,17 @@ Description::
 This instruction loads two 64-bit values into the two GP registers _rd1_ and _rd2_
 from the address _rs1_ + (zero_extend(_imm2_) << 4).
 
-The values of _rd1_, _rd2_ and _rs1_ must not be the same.
+The encoding of this instruction with equal _rd1_, _rd2_ and _rs1_ is reserved.
 
 Operation::
 [source,sail]
 --
-addr := rs1 + (zero_extend(imm2) << 4)
-rd1 := mem[addr+7:addr]
-rd2 := mem[addr+15:addr+8]
+if (rs1 != rd1 && rs != rd2 && rd1 != rd2) {
+    addr := rs1 + (zero_extend(imm2) << 4)
+    tmp1 := mem[addr+7:addr]
+    tmp2 := mem[addr+15:addr+8]
+    (reg[rd1], reg[rd2]) := (tmp1, tmp2)
+}
 --
 
 Permission::

--- a/xtheadmempair/lwd.adoc
+++ b/xtheadmempair/lwd.adoc
@@ -27,6 +27,11 @@ from the address _rs1_ + (zero_extend(_imm2_) << 3).
 
 The encoding of this instruction with equal _rd1_, _rd2_ and _rs1_ is reserved.
 
+Note, that there is no atomicity guarantee for this instruction.
+I.e., an implementation can realize this instruction in form of two
+memory transactions and an exception can be handled in-between, in which
+case the whole instruction will be re-executed.
+
 Operation::
 [source,sail]
 --

--- a/xtheadmempair/lwd.adoc
+++ b/xtheadmempair/lwd.adoc
@@ -25,14 +25,17 @@ Description::
 This instruction loads two signed 32-bit values into the two GP registers _rd1_ and _rd2_
 from the address _rs1_ + (zero_extend(_imm2_) << 3).
 
-The values of _rd1_, _rd2_ and _rs1_ must not be the same.
+The encoding of this instruction with equal _rd1_, _rd2_ and _rs1_ is reserved.
 
 Operation::
 [source,sail]
 --
-addr := rs1 + (zero_extend(imm2) << 3)
-reg[rd1] := sign_extend(mem[addr+3:addr])
-reg[rd2] := sign_extend(mem[addr+7:addr+3])
+if (rs1 != rd1 && rs != rd2 && rd1 != rd2) {
+    addr := rs1 + (zero_extend(imm2) << 3)
+    tmp1 := sign_extend(mem[addr+3:addr])
+    tmp2 := sign_extend(mem[addr+7:addr+3])
+    (reg[rd1], reg[rd2]) := (tmp1, tmp2)
+}
 --
 
 Permission::

--- a/xtheadmempair/lwud.adoc
+++ b/xtheadmempair/lwud.adoc
@@ -27,6 +27,11 @@ from the address _rs1_ + (zero_extend(_imm2_) << 3).
 
 The encoding of this instruction with equal _rd1_, _rd2_ and _rs1_ is reserved.
 
+Note, that there is no atomicity guarantee for this instruction.
+I.e., an implementation can realize this instruction in form of two
+memory transactions and an exception can be handled in-between, in which
+case the whole instruction will be re-executed.
+
 Operation::
 [source,sail]
 --

--- a/xtheadmempair/lwud.adoc
+++ b/xtheadmempair/lwud.adoc
@@ -25,14 +25,17 @@ Description::
 This instruction loads two unsigned 32-bit values into the two GP registers _rd1_ and _rd2_
 from the address _rs1_ + (zero_extend(_imm2_) << 3).
 
-The values of _rd1_, _rd2_ and _rs1_ must not be the same.
+The encoding of this instruction with equal _rd1_, _rd2_ and _rs1_ is reserved.
 
 Operation::
 [source,sail]
 --
-addr := rs1 + (zero_extend(imm2) << 3)
-reg[rd1] := zero_extend(mem[addr+3:addr])
-reg[rd2] := zero_extend(mem[addr+7:addr+3])
+if (rs1 != rd1 && rs != rd2 && rd1 != rd2) {
+    addr := rs1 + (zero_extend(imm2) << 3)
+    tmp1 := zero_extend(mem[addr+3:addr])
+    tmp2 := zero_extend(mem[addr+7:addr+3])
+    (reg[rd1], reg[rd2]) := (tmp1, tmp2)
+}
 --
 
 Permission::

--- a/xtheadmempair/sdd.adoc
+++ b/xtheadmempair/sdd.adoc
@@ -25,6 +25,11 @@ Description::
 This instruction stores two 64-bit values from the two GP registers _rd1_ and _rd2_
 to the address _rs1_ + (zero_extend(_imm2_) << 4).
 
+Note, that there is no atomicity guarantee for this instruction.
+I.e., an implementation can realize this instruction in form of two
+memory transactions and an exception can be handled in-between, in which
+case the whole instruction will be re-executed.
+
 Operation::
 [source,sail]
 --

--- a/xtheadmempair/swd.adoc
+++ b/xtheadmempair/swd.adoc
@@ -25,6 +25,11 @@ Description::
 This instruction loads two 32-bit values into the two GP registers _rd1_ and _rd2_
 from the address _rs1_ + (zero_extend(_imm2_) << 3).
 
+Note, that there is no atomicity guarantee for this instruction.
+I.e., an implementation can realize this instruction in form of two
+memory transactions and an exception can be handled in-between, in which
+case the whole instruction will be re-executed.
+
 Operation::
 [source,sail]
 --


### PR DESCRIPTION
During the review of the QEMU patchset a few questions regarding the mempair instructions showed up.
In particular, the following behavior should be clarified:
* What happens in case of overlapping register usage (load pair)?
* What atomicity guarantees are provided by mem pair instructions?

This PR attempts to address the questions by not adding any guarantees.

