### PR TITLE
memidx: Clarify non-overlapping register requirement

### DIFF
--- a/xtheadmemidx/lbia.adoc
+++ b/xtheadmemidx/lbia.adoc
@@ -25,13 +25,15 @@ Description::
 This instruction loads a sign extended 8-bit value into the GP register _rd_ from the address _rs1_.
 After the load, this instruction increments the value in _rs1_ by (sign_extend(_imm5_) << _imm2_) and writes the result back to _rs1_.
 
-The values of _rd_ and _rs1_ must not be the same.
+The encoding of this instruction with equal _rd_ and _rs1_ is reserved.
 
 Operation::
 [source,sail]
 --
-rd := sign_extend(mem[rs1])
-rs1 := rs1 + (sign_extend(imm5) << imm2)
+if (rs1 != rd) {
+    rd := sign_extend(mem[rs1])
+    rs1 := rs1 + (sign_extend(imm5) << imm2)
+}
 --
 
 Permission::

--- a/xtheadmemidx/lbib.adoc
+++ b/xtheadmemidx/lbib.adoc
@@ -25,13 +25,15 @@ Description::
 This instruction increments the value in _rs1_ by (sign_extend(_imm5_) << _imm2_) and writes the result back to _rs1_.
 After the increment of _rs1_, this instruction loads a sign extended 8-bit value into the GP register _rd_ from the (incremented) address _rs1_.
 
-The values of _rd_ and _rs1_ must not be the same.
+The encoding of this instruction with equal _rd_ and _rs1_ is reserved.
 
 Operation::
 [source,sail]
 --
-rs1 := rs1 + (sign_extend(imm5) << imm2)
-rd := sign_extend(mem[rs1])
+if (rs1 != rd) {
+    rs1 := rs1 + (sign_extend(imm5) << imm2)
+    rd := sign_extend(mem[rs1])
+}
 --
 
 Permission::

--- a/xtheadmemidx/lbuia.adoc
+++ b/xtheadmemidx/lbuia.adoc
@@ -25,13 +25,15 @@ Description::
 This instruction loads a zero extended 8-bit value into the GP register _rd_ from the address _rs1_.
 After the load, this instruction increments the value in _rs1_ by (sign_extend(_imm5_) << _imm2_) and writes the result back to _rs1_.
 
-The values of _rd_ and _rs1_ must not be the same.
+The encoding of this instruction with equal _rd_ and _rs1_ is reserved.
 
 Operation::
 [source,sail]
 --
-rs := zero_extend(mem[rs1])
-rs1 := rs1 + (sign_extend(imm5) << imm2)
+if (rs1 != rd) {
+    rs := zero_extend(mem[rs1])
+    rs1 := rs1 + (sign_extend(imm5) << imm2)
+}
 --
 
 Permission::

--- a/xtheadmemidx/lbuib.adoc
+++ b/xtheadmemidx/lbuib.adoc
@@ -25,13 +25,15 @@ Description::
 This instruction increments the value in _rs1_ by (sign_extend(_imm5_) << _imm2_) and writes the result back to _rs1_.
 After the increment of _rs1_, this instruction loads a zero extended 8-bit value into the GP register _rd_ from the (incremented) address _rs1_.
 
-The values of _rd_ and _rs1_ must not be the same.
+The encoding of this instruction with equal _rd_ and _rs1_ is reserved.
 
 Operation::
 [source,sail]
 --
-rs1 := rs1 + (sign_extend(imm5) << imm2)
-rd := zero_extend(mem[rs1])
+if (rs1 != rd) {
+    rs1 := rs1 + (sign_extend(imm5) << imm2)
+    rd := zero_extend(mem[rs1])
+}
 --
 
 Permission::

--- a/xtheadmemidx/ldia.adoc
+++ b/xtheadmemidx/ldia.adoc
@@ -25,13 +25,15 @@ Description::
 This instruction loads a sign extended 64-bit value into the GP register _rd_ from the address _rs1_.
 After the load, this instruction increments the value in _rs1_ by (sign_extend(_imm5_) << _imm2_) and writes the result back to _rs1_.
 
-The values of _rd_ and _rs1_ must not be the same.
+The encoding of this instruction with equal _rd_ and _rs1_ is reserved.
 
 Operation::
 [source,sail]
 --
-rd := sign_extend(mem[rs1+7:rs1])
-rs1 := rs1 + (sign_extend(imm5) << imm2)
+if (rs1 != rd) {
+    rd := sign_extend(mem[rs1+7:rs1])
+    rs1 := rs1 + (sign_extend(imm5) << imm2)
+}
 --
 
 Permission::

--- a/xtheadmemidx/ldib.adoc
+++ b/xtheadmemidx/ldib.adoc
@@ -25,13 +25,15 @@ Description::
 This instruction increments the value in _rs1_ by (sign_extend(_imm5_) << _imm2_) and writes the result back to _rs1_.
 After the increment of _rs1_, this instruction loads a sign extended 64-bit value into the GP register _rd_ from the (incremented) address _rs1_.
 
-The values of _rd_ and _rs1_ must not be the same.
+The encoding of this instruction with equal _rd_ and _rs1_ is reserved.
 
 Operation::
 [source,sail]
 --
-rs1 := rs1 + (sign_extend(imm5) << imm2)
-rd := sign_extend(mem[rs1+7:rs1])
+if (rs1 != rd) {
+    rs1 := rs1 + (sign_extend(imm5) << imm2)
+    rd := sign_extend(mem[rs1+7:rs1])
+}
 --
 
 Permission::

--- a/xtheadmemidx/lhia.adoc
+++ b/xtheadmemidx/lhia.adoc
@@ -25,13 +25,15 @@ Description::
 This instruction loads a sign extended 16-bit value into the GP register _rd_ from the address _rs1_.
 After the load, this instruction increments the value in _rs1_ by (sign_extend(_imm5_) << _imm2_) and writes the result back to _rs1_.
 
-The values of _rd_ and _rs1_ must not be the same.
+The encoding of this instruction with equal _rd_ and _rs1_ is reserved.
 
 Operation::
 [source,sail]
 --
-rd := sign_extend(mem[rs1+1:rs1])
-rs1 := rs1 + (sign_extend(imm5) << imm2)
+if (rs1 != rd) {
+    rd := sign_extend(mem[rs1+1:rs1])
+    rs1 := rs1 + (sign_extend(imm5) << imm2)
+}
 --
 
 Permission::

--- a/xtheadmemidx/lhib.adoc
+++ b/xtheadmemidx/lhib.adoc
@@ -25,13 +25,15 @@ Description::
 This instruction increments the value in _rs1_ by (sign_extend(_imm5_) << _imm2_) and writes the result back to _rs1_.
 After the increment of _rs1_, this instruction loads a sign extended 16-bit value into the GP register _rd_ from the (incremented) address _rs1_.
 
-The values of _rd_ and _rs1_ must not be the same.
+The encoding of this instruction with equal _rd_ and _rs1_ is reserved.
 
 Operation::
 [source,sail]
 --
-rs1 := rs1 + (sign_extend(imm5) << imm2)
-rd := sign_extend(mem[rs1+1:rs1])
+if (rs1 != rd) {
+    rs1 := rs1 + (sign_extend(imm5) << imm2)
+    rd := sign_extend(mem[rs1+1:rs1])
+}
 --
 
 Permission::

--- a/xtheadmemidx/lhuia.adoc
+++ b/xtheadmemidx/lhuia.adoc
@@ -25,13 +25,15 @@ Description::
 This instruction loads a zero extended 16-bit value into the GP register _rd_ from the address _rs1_.
 After the load, this instruction increments the value in _rs1_ by (sign_extend(_imm5_) << _imm2_) and writes the result back to _rs1_.
 
-The values of _rd_ and _rs1_ must not be the same.
+The encoding of this instruction with equal _rd_ and _rs1_ is reserved.
 
 Operation::
 [source,sail]
 --
-rd := zero_extend(mem[rs1+1:rs1])
-rs1 := rs1 + (sign_extend(imm5) << imm2)
+if (rs1 != rd) {
+    rd := zero_extend(mem[rs1+1:rs1])
+    rs1 := rs1 + (sign_extend(imm5) << imm2)
+}
 --
 
 Permission::

--- a/xtheadmemidx/lhuib.adoc
+++ b/xtheadmemidx/lhuib.adoc
@@ -25,13 +25,15 @@ Description::
 This instruction increments the value in _rs1_ by (sign_extend(_imm5_) << _imm2_) and writes the result back to _rs1_.
 After the increment of _rs1_, this instruction loads a zero extended 16-bit value into the GP register _rd_ from the (incremented) address _rs1_.
 
-The values of _rd_ and _rs1_ must not be the same.
+The encoding of this instruction with equal _rd_ and _rs1_ is reserved.
 
 Operation::
 [source,sail]
 --
-rs1 := rs1 + (sign_extend(imm5) << imm2)
-rd := zero_extend(mem[rs1+1:rs1])
+if (rs1 != rd) {
+    rs1 := rs1 + (sign_extend(imm5) << imm2)
+    rd := zero_extend(mem[rs1+1:rs1])
+}
 --
 
 Permission::

--- a/xtheadmemidx/lwia.adoc
+++ b/xtheadmemidx/lwia.adoc
@@ -25,13 +25,15 @@ Description::
 This instruction loads a sign extended 32-bit value into the GP register _rd_ from the address _rs1_.
 After the load, this instruction increments the value in _rs1_ by (sign_extend(_imm5_) << _imm2_) and writes the result back to _rs1_.
 
-The values of _rd_ and _rs1_ must not be the same.
+The encoding of this instruction with equal _rd_ and _rs1_ is reserved.
 
 Operation::
 [source,sail]
 --
-rd := sign_extend(mem[rs1+3:rs1])
-rs1 := rs1 + (sign_extend(imm5) << imm2)
+if (rs1 != rd) {
+    rd := sign_extend(mem[rs1+3:rs1])
+    rs1 := rs1 + (sign_extend(imm5) << imm2)
+}
 --
 
 Permission::

--- a/xtheadmemidx/lwib.adoc
+++ b/xtheadmemidx/lwib.adoc
@@ -25,13 +25,15 @@ Description::
 This instruction increments the value in _rs1_ by (sign_extend(_imm5_) << _imm2_) and writes the result back to _rs1_.
 After the increment of _rs1_, this instruction loads a sign extended 32-bit value into the GP register _rd_ from the (incremented) address _rs1_.
 
-The values of _rd_ and _rs1_ must not be the same.
+The encoding of this instruction with equal _rd_ and _rs1_ is reserved.
 
 Operation::
 [source,sail]
 --
-rs1 := rs1 + (sign_extend(imm5) << imm2)
-rd := sign_extend(mem[rs1+3:rs1])
+if (rs1 != rd) {
+    rs1 := rs1 + (sign_extend(imm5) << imm2)
+    rd := sign_extend(mem[rs1+3:rs1])
+}
 --
 
 Permission::

--- a/xtheadmemidx/lwuia.adoc
+++ b/xtheadmemidx/lwuia.adoc
@@ -25,13 +25,15 @@ Description::
 This instruction loads a zero extended 32-bit value into the GP register _rd_ from the address _rs1_.
 After the load, this instruction increments the value in _rs1_ by (sign_extend(_imm5_) << _imm2_) and writes the result back to _rs1_.
 
-The values of _rd_ and _rs1_ must not be the same.
+The encoding of this instruction with equal _rd_ and _rs1_ is reserved.
 
 Operation::
 [source,sail]
 --
-rd := zero_extend(mem[rs1+3:rs1])
-rs1 := rs1 + (sign_extend(imm5) << imm2)
+if (rs1 != rd) {
+    rd := zero_extend(mem[rs1+3:rs1])
+    rs1 := rs1 + (sign_extend(imm5) << imm2)
+}
 --
 
 Permission::

--- a/xtheadmemidx/lwuib.adoc
+++ b/xtheadmemidx/lwuib.adoc
@@ -25,13 +25,15 @@ Description::
 This instruction increments the value in _rs1_ by (sign_extend(_imm5_) << _imm2_) and writes the result back to _rs1_.
 After the increment of _rs1_, this instruction loads a zero extended 32-bit value into the GP register _rd_ from the (incremented) address _rs1_.
 
-The values of _rd_ and _rs1_ must not be the same.
+The encoding of this instruction with equal _rd_ and _rs1_ is reserved.
 
 Operation::
 [source,sail]
 --
-rs1 := rs1 + (sign_extend(imm5) << imm2)
-rd := zero_extend(mem[rs1+3:rs1])
+if (rs1 != rd) {
+    rs1 := rs1 + (sign_extend(imm5) << imm2)
+    rd := zero_extend(mem[rs1+3:rs1])
+}
 --
 
 Permission::


### PR DESCRIPTION
The specification requires that rd and rs1 must not be the same. Let's clarify this by stating that overlapping registers result in reserved opcodes.

This is similar to #21.