### PR TITLE
xtheadbb: clarify rotate-right instructions

### DIFF
--- a/xtheadbb/srri.adoc
+++ b/xtheadbb/srri.adoc
@@ -2,7 +2,7 @@
 ==== th.srri
 
 Synopsis::
-Perform a cyclic right shift.
+Rotate Right (by Immediate)
 
 Mnemonic::
 th.srri _rd_, _rs1_, _imm6_
@@ -16,20 +16,21 @@ Encoding::
     { bits:  3, name: 0x1, attr: ['Arithmetic'] },
     { bits:  5, name: 'rs1' },
     { bits:  6, name: 'imm6' },
-    { bits:  6, name: 0x04 },
+    { bits:  6, name: 0x04, attr: ['SRRI'] },
 ]}
 ....
 
 Description::
-This operation rotates the contents of _rs1_ by _imm6_ bits and stores the result in _rd_.
+This performs a rotate right of _rs1_ by least significant log2(XLEN) bits of _imm6_ and stores the result in _rd_.
 
-Operation::
+Operation (SAIL)::
 [source,sail]
 --
-if (xlen == 32)
-  imm6 &= 0x1f
-
-reg[rd] := (reg[rs1] >> imm6) | (reg[rs1] << (xlen - imm6))
+let rs1_val = X(rs1);
+let result : xlenbits = if sizeof(xlen) == 32
+                        then rs1_val >>> imm6[4..0]
+                        else rs1_val >>> imm5;
+X(rd) = result;
 --
 
 Permission::

--- a/xtheadbb/srriw.adoc
+++ b/xtheadbb/srriw.adoc
@@ -2,7 +2,7 @@
 ==== th.srriw
 
 Synopsis::
-Perform a cyclic right shift on word operand.
+Rotate Right Word (by Immediate)
 
 Mnemonic::
 th.srriw _rd_, _rs1_, _imm5_
@@ -16,18 +16,19 @@ Encoding::
     { bits:  3, name: 0x1, attr: ['Arithmetic'] },
     { bits:  5, name: 'rs1' },
     { bits:  5, name: 'imm5' },
-    { bits:  7, name: 0x0a },
+    { bits:  7, name: 0x0a, attr: ['SRRIW'] },
 ]}
 ....
 
 Description::
-This operation rotates the contents of the 32-bit value in _rs1_ by _imm5_ bits and stores the result in _rd_.
+This operation performs a rotate-right on on the least-significant word of _rs1_ by _imm5_ bits and stores the result in _rd_.
 
-Operation::
+Operation (SAIL)::
 [source,sail]
 --
-data := zext.w(reg[rs1])
-reg[rd] := (data >> imm5) | (data << (32 - imm5))
+let rs1_val = (X(rs1))[31..0];
+let result : xlenbits = EXTS(rs1_val >>> imm5);
+X(rd) = result;
 --
 
 Permission::


### PR DESCRIPTION
Bring the description and operational pseudocode for the rotate-right instructions in-line with other RISC-V specifications:
- replaced the 'cyclical shift' terminology with 'rotate'
- clarifies that this is a rotate _right_ in the description
- updates the operational pseudocode to SAIL
- corrects the th.srriw operational pseudocode to include the final sign-extension (and removes the initial zero-extension)

Signed-off-by: Philipp Tomsich <philipp.tomsich@vrull.eu>