### PR TITLE
mempair: Remove unneeded 5th imm operand in XTheadMemPair

### DIFF
--- a/xtheadmempair/ldd.adoc
+++ b/xtheadmempair/ldd.adoc
@@ -5,7 +5,7 @@ Synopsis::
 Load two 64-bit values from memory into two GPRs.
 
 Mnemonic::
-th.ldd _rd1_, _rd2_, (_rs1_), _imm2_, 4
+th.ldd _rd1_, _rd2_, (_rs1_), _imm2_
 
 Encoding::
 [wavedrom, , svg]

--- a/xtheadmempair/lwd.adoc
+++ b/xtheadmempair/lwd.adoc
@@ -5,7 +5,7 @@ Synopsis::
 Load two signed 32-bit values from memory into two GPRs.
 
 Mnemonic::
-th.lwd _rd1_, _rd2_, (_rs1_), _imm2_, 3
+th.lwd _rd1_, _rd2_, (_rs1_), _imm2_
 
 Encoding::
 [wavedrom, , svg]

--- a/xtheadmempair/lwud.adoc
+++ b/xtheadmempair/lwud.adoc
@@ -5,7 +5,7 @@ Synopsis::
 Load two unsigned 32-bit values from memory into two GPRs.
 
 Mnemonic::
-th.lwud _rd1_, _rd2_, (_rs1_), _imm2_, 3
+th.lwud _rd1_, _rd2_, (_rs1_), _imm2_
 
 Encoding::
 [wavedrom, , svg]

--- a/xtheadmempair/sdd.adoc
+++ b/xtheadmempair/sdd.adoc
@@ -5,7 +5,7 @@ Synopsis::
 Store two 64-bit values to memory from two GPRs.
 
 Mnemonic::
-th.sdd _rd1_, _rd2_, (_rs1_), _imm2_, 4
+th.sdd _rd1_, _rd2_, (_rs1_), _imm2_
 
 Encoding::
 [wavedrom, , svg]

--- a/xtheadmempair/swd.adoc
+++ b/xtheadmempair/swd.adoc
@@ -5,7 +5,7 @@ Synopsis::
 Store two 32-bit values to memory from two GPRs.
 
 Mnemonic::
-th.swd _rd1_, _rd2_, (_rs1_), _imm2_, 3
+th.swd _rd1_, _rd2_, (_rs1_), _imm2_
 
 Encoding::
 [wavedrom, , svg]


### PR DESCRIPTION
Actually, the `w`/`d` in the name has indicated the data width.