### PR TITLE
Swap vs2 and rs1/vs1 of xtheadvdot

### DIFF
--- a/xtheadvdot/vmaqa_vv.adoc
+++ b/xtheadvdot/vmaqa_vv.adoc
@@ -5,7 +5,7 @@ Synopsis::
 Four signed 8-bit multiply with 32-bit add.
 
 Mnemonic::
-th.vmaqa.vv _vd_, _vs1_, _vs2_
+th.vmaqa.vv _vd_, _vs2_, _vs1_
 
 Encoding::
 [wavedrom, , svg]

--- a/xtheadvdot/vmaqa_vx.adoc
+++ b/xtheadvdot/vmaqa_vx.adoc
@@ -5,7 +5,7 @@ Synopsis::
 Four signed 8-bit multiply with 32-bit add.
 
 Mnemonic::
-th.vmaqa.vx _vd_, _rs1_, _vs2_
+th.vmaqa.vx _vd_, _vs2_, _rs1_
 
 Encoding::
 [wavedrom, , svg]

--- a/xtheadvdot/vmaqasu_vv.adoc
+++ b/xtheadvdot/vmaqasu_vv.adoc
@@ -5,7 +5,7 @@ Synopsis::
 Four signed-unsigned 8-bit multiply with 32-bit add.
 
 Mnemonic::
-th.vmaqasu.vv _vd_, _vs1_, _vs2_
+th.vmaqasu.vv _vd_, _vs2_, _vs1_
 
 Encoding::
 [wavedrom, , svg]

--- a/xtheadvdot/vmaqasu_vx.adoc
+++ b/xtheadvdot/vmaqasu_vx.adoc
@@ -5,7 +5,7 @@ Synopsis::
 Four signed-unsigned 8-bit multiply with 32-bit add.
 
 Mnemonic::
-th.vmaqasu.vx _vd_, _rs1_, _vs2_
+th.vmaqasu.vx _vd_, _vs2_, _rs1_
 
 Encoding::
 [wavedrom, , svg]

--- a/xtheadvdot/vmaqau_vv.adoc
+++ b/xtheadvdot/vmaqau_vv.adoc
@@ -5,7 +5,7 @@ Synopsis::
 Four unsigned 8-bit multiply with 32-bit add.
 
 Mnemonic::
-th.vmaqau.vv _vd_, _vs1_, _vs2_
+th.vmaqau.vv _vd_, _vs2_, _vs1_
 
 Encoding::
 [wavedrom, , svg]

--- a/xtheadvdot/vmaqau_vx.adoc
+++ b/xtheadvdot/vmaqau_vx.adoc
@@ -5,7 +5,7 @@ Synopsis::
 Four unsigned 8-bit multiply with 32-bit add.
 
 Mnemonic::
-th.vmaqau.vx _vd_, _rs1_, _vs2_
+th.vmaqau.vx _vd_, _vs2_, _rs1_
 
 Encoding::
 [wavedrom, , svg]

--- a/xtheadvdot/vmaqaus_vx.adoc
+++ b/xtheadvdot/vmaqaus_vx.adoc
@@ -5,7 +5,7 @@ Synopsis::
 Four unsigned-signed 8-bit multiply with 32-bit add.
 
 Mnemonic::
-th.vmaqaus.vx _vd_, _rs1_, _vs2_
+th.vmaqaus.vx _vd_, _vs2_, _rs1_
 
 Encoding::
 [wavedrom, , svg]


### PR DESCRIPTION
To match mnemonic format convention in RISCV Vector Extension.