### PR TITLE
xtheadint: Fix missing instruction prefix in mnemonics

### DIFF
--- a/xtheadint/ipop.adoc
+++ b/xtheadint/ipop.adoc
@@ -5,7 +5,7 @@ Synopsis::
 Pop register context from the interrupt stack
 
 Mnemonic::
-ipop
+th.ipop
 
 Encoding::
 [wavedrom, , svg]

--- a/xtheadint/ipush.adoc
+++ b/xtheadint/ipush.adoc
@@ -5,7 +5,7 @@ Synopsis::
 Pushes register context on the interrupt stack
 
 Mnemonic::
-ipush
+th.ipush
 
 Encoding::
 [wavedrom, , svg]


### PR DESCRIPTION
XThead* instructions use the instruction prefix 'th.'. Let's add them to the description of th.ipush and th.ipop.