### PR TITLE
xtheadfmv: fmv.hw.x: Fix swapped operands in description

### DIFF
--- a/xtheadfmv/fmv_hw_x.adoc
+++ b/xtheadfmv/fmv_hw_x.adoc
@@ -21,7 +21,7 @@ Encoding::
 ....
 
 Description::
-This instruction stores the contents of the specified 32-bit GP register _fd_ in the upper 32-bit of the specified double-precision FP register _rs1_.
+This instruction stores the contents of the specified 32-bit GP register _rs1_ in the upper 32-bit of the specified double-precision FP register _fd_.
 
 Operation::
 [source,sail]


### PR DESCRIPTION
A recent change fixed the encoding and description of the th.fmv.hw.x instruction. Unfortunately, the resulting description has swapped operands. This patch fixes the description.

@majin2020 
@Cooper-Qu 