### PR TITLE
spec: Add XTheadMaee

### DIFF
--- a/xthead.adoc
+++ b/xthead.adoc
@@ -50,3 +50,5 @@ include::xtheadvdot.adoc[]
 include::xtheadvector.adoc[]
 
 include::intrinsic.adoc[]
+
+include::xtheadmaee.adoc[]

--- a/xtheadmaee.adoc
+++ b/xtheadmaee.adoc
@@ -1,0 +1,36 @@
+[#xtheadmaee]
+== Extend MMU address attribute (XTheadMaee)
+
+[NOTE,caption=Frozen]
+The `XTheadMaee` extension is `stable`.
+
+Extension version: 1.0.
+
+The `XTheadMaee` ISA extension provides a way to configure page attributes of addresses when virtual addresses are translated into physical addresses by extended page attributes in page table entries (PTEs).
+
+The `XTheadMaee` extension is a non-standard non-conforming extension. TheadMaee uses preserved [60:63] bits of PTE, which have been allocted to SVPBMT and SVNAPOT. This conflict is not on purpose, but the result of issues in the past that have been resolved since. Therefore, the XTheadMaee extension and the SVPBMT or SVNAPOT extension are in conflict. In other words, tools should not allow to enable the TheadMaee extension and the SVPBMT or SVNAPOT at the same time and should report an error if both are enabled by the user.
+
+The table below describes the page attributes corresponding to each memory type:
+
+[cols="^12,3,3,3",stripes=even,options="header"]
+|===
+| Memory type            | SO | C | B
+| Cacheable memory       | 0  | 1 | 1
+| Non-cacheable memory   | 0  | 0 | 1
+| Bufferable device      | 1  | 0 | 1
+| Non-bufferable device  | 1  | 0 | 0
+|===
+
+The table below describes extend page attributes in PTE:
+[cols="^3,^3,12",stripes=even,options="header"]
+|===
+| Fields  | Bit | Meaning
+| SO      | 63  | Strong order
+| C       | 62  | Cacheable
+| B       | 61  | Bufferable
+| T       | 60  | Trustable
+|===
+
+XTheadMaee depends on the value of the MAEE field in extended custom register TH_MXSTATUS. If the MAEE field is 1, page attributes of addresses are determined by extended page attributes in corresponding PTEs. If the MAEE field is 0, page attributes of addresses are determined by the sysmap.h file.
+
+TH_MXSTATUS register is 64 bits wide and is readable and writable in M-mode. Accesses in non-M-mode will cause an illegal instruction exception. MAEE is in the 21 bit of TH_MXSTATUS. If MVENDORID is 0x5B7, OS kernel should refer to TH_MXSTATUS MAEE as the enable status of XTheadMaee.


### PR DESCRIPTION
We name the mxstatus maee to a specific extension XTheadMaee, which describles whether enable the the extend page attributes in PTE or not. 