### PR TITLE
xtheadvector: Move intrinsics into the XTheadVector chapter

### DIFF
--- a/xthead.adoc
+++ b/xthead.adoc
@@ -50,6 +50,4 @@ include::xtheadint.adoc[]
 include::xtheadvdot.adoc[]
 include::xtheadvector.adoc[]
 
-include::intrinsic.adoc[]
-
 include::xtheadmaee.adoc[]

--- a/xtheadvector.adoc
+++ b/xtheadvector.adoc
@@ -53,4 +53,4 @@ but also ensure that future T-Head CPUs without `XTheadVector` won't be falsely 
 
 === Intrinsics
 
-The list of intrinsic functions for `XTheadVector` can be found in <<#intrinsics>>.
+include::xtheadvector/intrinsics.adoc[]

--- a/xtheadvector/intrinsics.adoc
+++ b/xtheadvector/intrinsics.adoc
@@ -1,12 +1,12 @@
 [#intrinsics]
-== Intrinsic support for XTheadVector
+=== Intrinsic support for XTheadVector
 
-=== Introduction
+==== Introduction
 The RISC-V `XTheadVector` C intrinsics provide users interfaces in the C language level to directly leverage XTheadVector (<<#xtheadvector>>), with assistance from the compiler in handling instruction scheduling and register allocation.
 
 The `XTheadVector` intrinsics support all RVV intrinsic functions with the restriction of missing support for fractional LMUL values (https://github.com/riscv-non-isa/rvv-intrinsic-doc). Additionally, the `XTheadVector` extension intrinsics API extends the RVV intrinsics API by new load/store functions and integer extract functions (<<#appendix>>).
 
-=== Test macro
+==== Test macro
 The `__riscv_th_v_intrinsic` macro is the C macro to test the compiler's support for the RISC-V `XTheadVector` extension intrinsics. The API extension is optional and targeting the vendor extension `XTheadVector`.
 
 The value of the test macro is defined as its version, which is computed using the following formula. The formula is identical to what is defined in the RISC-V C API specification (https://github.com/riscv-non-isa/rvv-intrinsic-doc) .
@@ -17,7 +17,7 @@ The value of the test macro is defined as its version, which is computed using t
 
 For example, the v1.0 version should define the macro with value `1000000`.
 
-=== Availability
+==== Availability
 
 With `<riscv_th_vector.h>` included, availability of intrinsic variants depends on the required architecture of their corresponding xtheadvector instructions. The supported architecture is specified to the compiler using the `-march` option.
 
@@ -34,7 +34,7 @@ We suggest guarding the inclusion with the test macro.
 #endif
 ----
 
-=== Example
+==== Example
 
 The following shows an example with `vlb` intrinsic of `vint32m1_t` output vector type, `vsb` intrinsic of `vint32m1_t` input vector type as well as `vadd` intrinsic of `vint32m1_t` input/output vector type.
 
@@ -51,9 +51,10 @@ void function (void *in, void *out)
 ----
 
 [#appendix]
-=== Additional Intrinsic Functions for XTheadVector
+==== Additional Intrinsic Functions for XTheadVector
+
 [[xtheadvector-unit-stride-load]]
-==== XtheadVector Unit-Stride Load Intrinsics
+===== XtheadVector Unit-Stride Load Intrinsics
 
 [,c]
 ----
@@ -206,7 +207,7 @@ vuint64m8_t __riscv_th_vlwu_v_u64m8_m (vbool8_t mask, const uint64_t *a, size_t 
 ----
 
 [[xtheadvector-unit-stride-store]]
-==== XTheadVector Unit-Stride Store Intrinsics
+===== XTheadVector Unit-Stride Store Intrinsics
 
 [,c]
 ----
@@ -310,7 +311,7 @@ void __riscv_th_vsw_v_u32m8_m (vbool4_t mask, uint32_t *a, vuint32m8_t b, size_t
 ----
 
 [[xtheadvectorvector-strided-load]]
-==== XTheadVector Strided Load Intrinsics
+===== XTheadVector Strided Load Intrinsics
 
 [,c]
 ----
@@ -462,7 +463,7 @@ vuint64m8_t __riscv_th_vlswu_v_u64m8_m (vbool8_t mask, const uint64_t *a, size_t
 ----
 
 [[xtheadvector-strided-store]]
-==== XTheadVector Strided Store Intrinsics
+===== XTheadVector Strided Store Intrinsics
 
 [,c]
 ----
@@ -566,7 +567,7 @@ void __riscv_th_vssw_v_u32m8_m (vbool4_t mask, uint32_t *a, size_t stride, vuint
 ----
 
 [[xtheadvector-indexed-load]]
-==== XTheadVector Indexed Load Intrinsics
+===== XTheadVector Indexed Load Intrinsics
 
 [,c]
 ----
@@ -718,7 +719,7 @@ vuint64m8_t __riscv_th_vlxwu_v_u64m8_m (vbool8_t mask, const uint64_t *a, vuint6
 ----
 
 [[xtheadvector-indexed-store]]
-==== XTheadVector Indexed Store Intrinsics
+===== XTheadVector Indexed Store Intrinsics
 
 [,c]
 ----
@@ -871,7 +872,7 @@ void __riscv_th_vsuxw_v_u32m8_m (vbool4_t mask, uint32_t *a, vuint32m8_t indexed
 
 
 [[xtheadvector-integer-extract]]
-==== XTheadVector Integer Extract Intrinsics
+===== XTheadVector Integer Extract Intrinsics
 
 [,c]
 ----


### PR DESCRIPTION
There is no strong reason to separate the intrinsic specification from the ISA specification. So let's make that a subchapter.