### PR TITLE
Introduce th.mxstatus CSR

### DIFF
--- a/intro.adoc
+++ b/intro.adoc
@@ -24,6 +24,7 @@ in many T-Head processors.
 The T-Head extension collection follows the principles of the RISC-V ISA.
 The collection consists of the following ISA extensions:
 
+* `XTheadMxStatus` provides a CSR to probe the availability of XThead* extensions.
 * `XTheadCmo` provides instructions for cache management.
 * `XTheadSync` provides instructions for multi-processor synchronization.
 * `XTheadBa` provides instructions for address calculations.
@@ -57,19 +58,9 @@ Some instruction are only available if the system implements
 the `D` extension. To highlight the availability, each
 floating-point extension document this for each instruction.
 
-=== Enablement of extensions and instructions
-
-All extensions and instructions are expected to be enabled at all times.
-The instructions can be used at any time when executing in the documented
-privilege levels, that permit the execution of the instruction.
-
-However, there might be SoC-specific mechanisms to ensure this behaviour.
-E.g. the T-Head C906 requires the CSR field `mxstatus.theadisaee` to
-be set to `1` to enable the ISA extensions.
-Another example is the CSR field `mxstatus.ucme` of the T-Head C906,
-that is required to be set to `1` in order to execute cache management
-instructions in `U` mode (if the instruction is documented that this
-is permitted).
+For probing of the extension's availability the extension
+`Zicsr` is required to read out the `th.mxstatus` CSR.
+Refer to <<#xtheadmxstatus>> for more information about the `th.mxstatus` CSR.
 
 === Lifecycle
 

--- a/xthead.adoc
+++ b/xthead.adoc
@@ -34,6 +34,7 @@ include::docinfo.adoc[]
 
 include::intro.adoc[]
 
+include::xtheadmxstatus.adoc[]
 include::xtheadcmo.adoc[]
 include::xtheadsync.adoc[]
 include::xtheadba.adoc[]

--- a/xtheadba.adoc
+++ b/xtheadba.adoc
@@ -17,6 +17,13 @@ The table below gives an overview of the instructions:
 | Y    | Y    | th.addsl _rd_, _rs1_, _rs2_, _imm2_ | <<#xtheadba-insns-addsl>>
 |===
 
+=== Availability
+
+The `XTheadBa` extension's availability can be probed via the
+`th.mxstatus`.THEADISAEE bit (bit 22).
+The `XTheadBa` extension is available if and only if this bit is `1`.
+Refer to <<#xtheadmxstatus>> for more information about the `th.mxstatus` CSR.
+
 [#xtheadba-insns,reftext="Instructions"]
 === Instructions
 include::xtheadba/addsl.adoc[]

--- a/xtheadbb.adoc
+++ b/xtheadbb.adoc
@@ -24,6 +24,13 @@ The table below gives an overview of the instructions:
 | Y    | Y    | th.tstnbz _rd_, _rs1_ | <<#xtheadbb-insns-tstnbz>>
 |===
 
+=== Availability
+
+The `XTheadBb` extension's availability can be probed via the
+`th.mxstatus`.THEADISAEE bit (bit 22).
+The `XTheadBb` extension is available if and only if this bit is `1`.
+Refer to <<#xtheadmxstatus>> for more information about the `th.mxstatus` CSR.
+
 [#xtheadbb-insns,reftext="Instructions"]
 === Instructions
 include::xtheadbb/srri.adoc[]

--- a/xtheadbs.adoc
+++ b/xtheadbs.adoc
@@ -16,6 +16,13 @@ The table below gives an overview of the instructions:
 | Y    | Y    | th.tst _rd_, _rs1_, _imm6_ | <<#xtheadbs-insns-tst>>
 |===
 
+=== Availability
+
+The `XTheadBs` extension's availability can be probed via the
+`th.mxstatus`.THEADISAEE bit (bit 22).
+The `XTheadBs` extension is available if and only if this bit is `1`.
+Refer to <<#xtheadmxstatus>> for more information about the `th.mxstatus` CSR.
+
 [#xtheadbs-insns,reftext="Instructions"]
 === Instructions
 include::xtheadbs/tst.adoc[]

--- a/xtheadcmo.adoc
+++ b/xtheadcmo.adoc
@@ -43,6 +43,17 @@ Instructions that are executed without the required HW requirements available
 visible state, except for advancing the program counter and incrementing any applicable
 performance counters (i.e. it behaves like executing a `NOP` instruction).
 
+=== Availability
+
+The `XTheadCmo` extension's availability can be probed via the
+`th.mxstatus`.THEADISAEE bit (bit 22).
+The `XTheadCmo` extension is available if and only if this bit is `1`.
+Refer to <<#xtheadmxstatus>> for more information about the `th.mxstatus` CSR.
+
+The execution of U-mode instructions (i.e., instructions that are documented
+to be executed in U-mode) is only permitted if and only if
+the `th.mxstatus`.UCME bit (bit 16) is `1`.
+
 [#insns,reftext="Instructions"]
 === Instructions
 include::xtheadcmo/dcache_call.adoc[]

--- a/xtheadcondmov.adoc
+++ b/xtheadcondmov.adoc
@@ -17,6 +17,13 @@ The table below gives an overview of the instructions:
 | Y    | Y    | th.mvnez _rd_, _rs1_, _rs2_ | <<#xtheadcondmov-insns-mvnez>>
 |===
 
+=== Availability
+
+The `XTheadCondMov` extension's availability can be probed via the
+`th.mxstatus`.THEADISAEE bit (bit 22).
+The `XTheadCondMov` extension is available if and only if this bit is `1`.
+Refer to <<#xtheadmxstatus>> for more information about the `th.mxstatus` CSR.
+
 [#xtheadcondmov-insns,reftext="Instructions"]
 === Instructions
 include::xtheadcondmov/mveqz.adoc[]

--- a/xtheadfmemidx.adoc
+++ b/xtheadfmemidx.adoc
@@ -29,6 +29,13 @@ Additionally at least the `F` extension needs to be available.
 In order to have all instructions available, the `D` extensions
 needs to be implemented.
 
+=== Availability
+
+The `XTheadFMemIdx` extension's availability can be probed via the
+`th.mxstatus`.THEADISAEE bit (bit 22).
+The `XTheadFMemIdx` extension is available if and only if this bit is `1`.
+Refer to <<#xtheadmxstatus>> for more information about the `th.mxstatus` CSR.
+
 [#xtheadfmemidx-insns,reftext="Instructions"]
 === Instructions
 include::xtheadfmemidx/flrd.adoc[]

--- a/xtheadfmv.adoc
+++ b/xtheadfmv.adoc
@@ -19,6 +19,13 @@ The table below gives an overview of the instructions:
 | Y    | N    | th.fmv.x.hw  _rd_, _fs1_ | <<#xtheadfmv-insns-fmv_x_hw>>
 |===
 
+=== Availability
+
+The `XTheadFmv` extension's availability can be probed via the
+`th.mxstatus`.THEADISAEE bit (bit 22).
+The `XTheadFmv` extension is available if and only if this bit is `1`.
+Refer to <<#xtheadmxstatus>> for more information about the `th.mxstatus` CSR.
+
 [#xtheadfmv-insns,reftext="Instructions"]
 === Instructions
 include::xtheadfmv/fmv_x_hw.adoc[]

--- a/xtheadint.adoc
+++ b/xtheadint.adoc
@@ -17,6 +17,13 @@ The table below gives an overview of the instructions:
 | Y    | Y    | th.ipop  | <<#xtheadint-insns-ipop>>
 |===
 
+=== Availability
+
+The `XTheadInt` extension's availability can be probed via the
+`th.mxstatus`.THEADISAEE bit (bit 22).
+The `XTheadInt` extension is available if and only if this bit is `1`.
+Refer to <<#xtheadmxstatus>> for more information about the `th.mxstatus` CSR.
+
 [#xtheadint-insns,reftext="Instructions"]
 === Instructions
 include::xtheadint/ipush.adoc[]

--- a/xtheadmac.adoc
+++ b/xtheadmac.adoc
@@ -21,6 +21,13 @@ The table below gives an overview of the instructions:
 | Y    | Y    | th.mulsw _rd_, _rs1_, _rs2_ | <<#xtheadmac-insns-mulsw>>
 |===
 
+=== Availability
+
+The `XTheadMac` extension's availability can be probed via the
+`th.mxstatus`.THEADISAEE bit (bit 22).
+The `XTheadMac` extension is available if and only if this bit is `1`.
+Refer to <<#xtheadmxstatus>> for more information about the `th.mxstatus` CSR.
+
 [#xtheadmac-insns,reftext="Instructions"]
 === Instructions
 include::xtheadmac/mula.adoc[]

--- a/xtheadmaee.adoc
+++ b/xtheadmaee.adoc
@@ -31,6 +31,9 @@ The table below describes extend page attributes in PTE:
 | T       | 60  | Trustable
 |===
 
-XTheadMaee depends on the value of the MAEE field in extended custom register TH_MXSTATUS. If the MAEE field is 1, page attributes of addresses are determined by extended page attributes in corresponding PTEs. If the MAEE field is 0, page attributes of addresses are determined by the sysmap.h file.
+=== Availability
 
-TH_MXSTATUS register is 64 bits wide and is readable and writable in M-mode. Accesses in non-M-mode will cause an illegal instruction exception. MAEE is in the 21 bit of TH_MXSTATUS. If MVENDORID is 0x5B7, OS kernel should refer to TH_MXSTATUS MAEE as the enable status of XTheadMaee.
+The `XTheadMaee` extension's availability can be probed via the
+`th.mxstatus`.MAEE bit (bit 21).
+The `XTheadMaee` extension is available if and only if this bit is `1`.
+Refer to <<#xtheadmxstatus>> for more information about the `th.mxstatus` CSR.

--- a/xtheadmemidx.adoc
+++ b/xtheadmemidx.adoc
@@ -60,6 +60,13 @@ The table below gives an overview of the instructions:
 | N    | Y    | th.surd   _rd_, _rs1_, _rs2_, _imm2_    | <<#xtheadmemidx-insns-surd>>
 |===
 
+=== Availability
+
+The `XTheadMemIdx` extension's availability can be probed via the
+`th.mxstatus`.THEADISAEE bit (bit 22).
+The `XTheadMemIdx` extension is available if and only if this bit is `1`.
+Refer to <<#xtheadmxstatus>> for more information about the `th.mxstatus` CSR.
+
 [#xtheadmemidx-insns,reftext="Instructions"]
 === Instructions
 include::xtheadmemidx/lbia.adoc[]

--- a/xtheadmempair.adoc
+++ b/xtheadmempair.adoc
@@ -20,6 +20,13 @@ The table below gives an overview of the instructions:
 | Y    | Y    | th.swd  _rd1_, _rd2_, (_rs1_), _imm2_, 3 | <<#xtheadmempair-insns-swd>>
 |===
 
+=== Availability
+
+The `XTheadMemPair` extension's availability can be probed via the
+`th.mxstatus`.THEADISAEE bit (bit 22).
+The `XTheadMemPair` extension is available if and only if this bit is `1`.
+Refer to <<#xtheadmxstatus>> for more information about the `th.mxstatus` CSR.
+
 [#xtheadmempair-insns,reftext="Instructions"]
 === Instructions
 include::xtheadmempair/ldd.adoc[]

--- a/xtheadmxstatus.adoc
+++ b/xtheadmxstatus.adoc
@@ -1,0 +1,53 @@
+[#xtheadmxstatus]
+== T-Head extension status register (XTheadMxStatus)
+
+[NOTE,caption=Frozen]
+The `XTheadMxStatus` extension is `stable`.
+
+The `XTheadMxStatus` ISA extension provides the `th.mxstatus` CSR that holds
+status information and allows to control T-Head custom extensions.
+
+Extension version: 1.0.
+
+The `th.mxstatus` CSR is 64 bits wide, has the address `0x7C0` and is readable
+and writable in M-mode only.
+Accesses from other modes will trigger an illegal instruction exception.
+
+The bit assignment of this CSR are:
+
+* Bit 0-7: 0
+* Bit 0-21: reserved (*WPRI*)
+* Bit 22: THEADISAEE
+* Bit 23-63: reserved (*WPRI*)
+
+The `th.mxstatus`.THEADISAEE bit controls the availability of a range of XThead*
+extensions. If the bit is set, these extensions are available, otherwise not
+(implying that custom instructions will raise an illegal instruction exception).
+The following XThead* extensions are enabled with this bit:
+
+* `XTheadCmo`
+* `XTheadSync`
+* `XTheadBa`
+* `XTheadBb`
+* `XTheadBs`
+* `XTheadCondMov`
+* `XTheadMemIdx`
+* `XTheadMemPair`
+* `XTheadFMemIdx`
+* `XTheadMac`
+* `XTheadFmv` (only available if `XLEN` is 32)
+* `XTheadInt` (only available if `XLEN` is 32)
+
+[NOTE]
+The `th.mxstatus`.THEADISAEE bit is not expected to be cleared.
+The behaviour of clearing this bit is undefined.
+Its main purpose is to be read by M-mode firmware for the purpose
+of discovering available extensions.
+
+The reserved bits of the `th.mxstatus` CSR may be defined
+in other XThead* extensions.
+
+=== Availability
+
+The `th.mxstatus` CSR is available on all systems whose `mvendorid` CSR
+holds a value of `0x5B7`.

--- a/xtheadsync.adoc
+++ b/xtheadsync.adoc
@@ -20,6 +20,13 @@ The table below gives an overview of the instructions:
 | Y    | Y    | th.sync.is                  | <<#xtheadsync-insns-sync-is>>
 |===
 
+=== Availability
+
+The `XTheadSync` extension's availability can be probed via the
+`th.mxstatus`.THEADISAEE bit (bit 22).
+The `XTheadSync` extension is available if and only if this bit is `1`.
+Refer to <<#xtheadmxstatus>> for more information about the `th.mxstatus` CSR.
+
 [#xtheadsync-insns,reftext="Instructions"]
 === Instructions
 include::xtheadsync/sfence_vmas.adoc[]


### PR DESCRIPTION
To implement proper extension discovery, we need to specify a mechanism to identify the availability of XThead* extension in a system. This mechanism already exists with the th.mxstatus register's THEADISAEE bit. Let's document this CSR.

Other bits than THEADISAEE are either 0 or defined as WPRI. This allows to define them in other extensions (e.g. UCME is defined as part of XTheadCmo and MAEE is defined as part of XTheadMaee).

The th.mxstatus CSR is defined to be available on all system's with a mvendorid or 0x5B7.